### PR TITLE
Use fused mul-add instructions where possible

### DIFF
--- a/fastapprox_tests/tests/compare.rs
+++ b/fastapprox_tests/tests/compare.rs
@@ -1,80 +1,92 @@
 #![cfg(test)]
 
+extern crate fastapprox;
 extern crate special;
 extern crate statrs;
-extern crate fastapprox;
 
-use std::convert::Into;
 use fastapprox::{fast, faster};
 use statrs::function::erf;
+use std::convert::Into;
 
 mod c;
 
 const FLOATS: &[f32] = &[-5.0, -0.25, -0.05, 0.0, 0.05, 1.0, 2.0, 3.0, 10.0];
 const POS_FLOATS: &[f32] = &[0.01, 0.05, 1.0, 2.1, 3.5, 100.0];
 const BETWEEN_ONES: &[f32] = &[-0.9, -0.5, -0.1, -0.01, 0.0, 0.01, 0.1, 0.5, 0.9];
-const BETWEEN_PIS: &[f32] = &[-3.14, -1.5, -1.0, -0.5, -0.1, -0.01, 0.0, 0.01, 0.1, 0.5, 1.0, 1.5, 3.14];
-const BETWEEN_HALFPIS: &[f32] = &[-1.56, -1.5, -1.0, -0.5, -0.1, -0.01, 0.0, 0.01, 0.1, 0.5, 1.0, 1.5, 1.56];
+const BETWEEN_PIS: &[f32] = &[
+    -3.14, -1.5, -1.0, -0.5, -0.1, -0.01, 0.0, 0.01, 0.1, 0.5, 1.0, 1.5, 3.14,
+];
+const BETWEEN_HALFPIS: &[f32] = &[
+    -1.56, -1.5, -1.0, -0.5, -0.1, -0.01, 0.0, 0.01, 0.1, 0.5, 1.0, 1.5, 1.56,
+];
 
 fn compare<F1, F2, T>(func: F1, base: F2, values: &[f32], tolerance: T)
-    where
-        F1: Fn(f32) -> f32,
-        F2: Fn(f32) -> f32,
-        T: Into<Option<f32>>
+where
+    F1: Fn(f32) -> f32,
+    F2: Fn(f32) -> f32,
+    T: Into<Option<f32>>,
 {
     let tol = tolerance.into();
     for value in values {
         let r1 = func(*value);
         let r2 = base(*value);
         if let Some(tolerance) = tol {
-            let d = if r2.abs() < 0.1 { (r1 - r2).abs() } else { ((r1 - r2) / r2).abs() };
-            assert!(d < tolerance, "func({}) = {}, but base({}) = {}, Δ == {}", value, r1, value, r2, d);
+            let d = if r2.abs() < 0.1 {
+                (r1 - r2).abs()
+            } else {
+                ((r1 - r2) / r2).abs()
+            };
+            assert!(
+                d < tolerance,
+                "func({}) = {}, but base({}) = {}, Δ == {}",
+                value,
+                r1,
+                value,
+                r2,
+                d
+            );
         } else {
-            assert_eq!(r1, r2, "func({}) = {}, but base({}) = {}", value, r1, value, r2);
+            assert_eq!(
+                r1, r2,
+                "func({}) = {}, but base({}) = {}",
+                value, r1, value, r2
+            );
         }
     }
 }
 
-fn compare_exact<F1, F2>(func: F1, base: F2, values: &[f32])
-    where
-        F1: Fn(f32) -> f32,
-        F2: Fn(f32) -> f32
-{
-    compare(func, base, values, None);
-}
-
 fn compare_near<F1, F2>(func: F1, base: F2, values: &[f32])
-    where
-        F1: Fn(f32) -> f32,
-        F2: Fn(f32) -> f32
+where
+    F1: Fn(f32) -> f32,
+    F2: Fn(f32) -> f32,
 {
     compare(func, base, values, 0.01);
 }
 
 fn compare_far<F1, F2>(func: F1, base: F2, values: &[f32])
-    where
-        F1: Fn(f32) -> f32,
-        F2: Fn(f32) -> f32
+where
+    F1: Fn(f32) -> f32,
+    F2: Fn(f32) -> f32,
 {
     compare(func, base, values, 0.15);
 }
 
 #[test]
 fn test_pow2_approx() {
-    compare_exact(fast::pow2, c::fastpow2, FLOATS);
-    compare_exact(faster::pow2, c::fasterpow2, FLOATS);
+    compare_near(fast::pow2, c::fastpow2, FLOATS);
+    compare_near(faster::pow2, c::fasterpow2, FLOATS);
 }
 
 #[test]
 fn test_pow2_exact() {
-    compare_near(fast::pow2, |x| (2.0_f32).powf(x) , FLOATS);
-    compare_far(faster::pow2, |x| (2.0_f32).powf(x) , FLOATS);
+    compare_near(fast::pow2, |x| (2.0_f32).powf(x), FLOATS);
+    compare_far(faster::pow2, |x| (2.0_f32).powf(x), FLOATS);
 }
 
 #[test]
 fn test_log2_approx() {
-    compare_exact(fast::log2, c::fastlog2, POS_FLOATS);
-    compare_exact(faster::log2, c::fasterlog2, POS_FLOATS);
+    compare_near(fast::log2, c::fastlog2, POS_FLOATS);
+    compare_near(faster::log2, c::fasterlog2, POS_FLOATS);
 }
 
 #[test]
@@ -85,8 +97,8 @@ fn test_log2_exact() {
 
 #[test]
 fn test_ln_approx() {
-    compare_exact(fast::ln, c::fastlog, POS_FLOATS);
-    compare_exact(faster::ln, c::fasterlog, POS_FLOATS);
+    compare_near(fast::ln, c::fastlog, POS_FLOATS);
+    compare_near(faster::ln, c::fasterlog, POS_FLOATS);
 }
 
 #[test]
@@ -97,8 +109,8 @@ fn test_ln_exact() {
 
 #[test]
 fn test_exp_approx() {
-    compare_exact(fast::exp, c::fastexp, FLOATS);
-    compare_exact(faster::exp, c::fasterexp, FLOATS);
+    compare_near(fast::exp, c::fastexp, FLOATS);
+    compare_near(faster::exp, c::fasterexp, FLOATS);
 }
 
 #[test]
@@ -109,8 +121,8 @@ fn test_exp_exact() {
 
 #[test]
 fn test_sigmoid_approx() {
-    compare_exact(fast::sigmoid, c::fastsigmoid, FLOATS);
-    compare_exact(faster::sigmoid, c::fastersigmoid, FLOATS);
+    compare_near(fast::sigmoid, c::fastsigmoid, FLOATS);
+    compare_near(faster::sigmoid, c::fastersigmoid, FLOATS);
 }
 
 #[test]
@@ -121,68 +133,108 @@ fn test_sigmoid_exact() {
 
 #[test]
 fn test_lgamma_approx() {
-    compare_exact(fast::ln_gamma, c::fastlgamma, POS_FLOATS);
-    compare_exact(faster::ln_gamma, c::fasterlgamma, POS_FLOATS);
+    compare_near(fast::ln_gamma, c::fastlgamma, POS_FLOATS);
+    compare_near(faster::ln_gamma, c::fasterlgamma, POS_FLOATS);
 }
 
 #[test]
 fn test_lgamma_exact() {
-    compare_near(fast::ln_gamma, |x| special::Gamma::ln_gamma(x as f64).0 as f32, POS_FLOATS);
-    compare_far(faster::ln_gamma, |x| special::Gamma::ln_gamma(x as f64).0 as f32, POS_FLOATS);
+    compare_near(
+        fast::ln_gamma,
+        |x| special::Gamma::ln_gamma(x as f64).0 as f32,
+        POS_FLOATS,
+    );
+    compare_far(
+        faster::ln_gamma,
+        |x| special::Gamma::ln_gamma(x as f64).0 as f32,
+        POS_FLOATS,
+    );
 }
 
 #[test]
 fn test_digamma_approx() {
-    compare_exact(fast::digamma, c::fastdigamma, POS_FLOATS);
-    compare_exact(faster::digamma, c::fasterdigamma, POS_FLOATS);
+    compare_near(fast::digamma, c::fastdigamma, POS_FLOATS);
+    compare_near(faster::digamma, c::fasterdigamma, POS_FLOATS);
 }
 
 #[test]
 fn test_digamma_exact() {
-    compare_near(fast::digamma, |x| special::Gamma::digamma(x as f64) as f32, POS_FLOATS);
-    compare_far(faster::digamma, |x| special::Gamma::digamma(x as f64) as f32, POS_FLOATS);
+    compare_near(
+        fast::digamma,
+        |x| special::Gamma::digamma(x as f64) as f32,
+        POS_FLOATS,
+    );
+    compare_far(
+        faster::digamma,
+        |x| special::Gamma::digamma(x as f64) as f32,
+        POS_FLOATS,
+    );
 }
 
 #[test]
 fn test_erf_approx() {
-    compare_exact(fast::erf, c::fasterf, POS_FLOATS);
-    compare_exact(faster::erf, c::fastererf, POS_FLOATS);
+    compare_near(fast::erf, c::fasterf, POS_FLOATS);
+    compare_near(faster::erf, c::fastererf, POS_FLOATS);
 }
 
 #[test]
 fn test_erf_exact() {
-    compare_near(fast::erf, |x| special::Error::error(x as f64) as f32, POS_FLOATS);
-    compare_far(faster::erf, |x| special::Error::error(x as f64) as f32, POS_FLOATS);
+    compare_near(
+        fast::erf,
+        |x| special::Error::error(x as f64) as f32,
+        POS_FLOATS,
+    );
+    compare_far(
+        faster::erf,
+        |x| special::Error::error(x as f64) as f32,
+        POS_FLOATS,
+    );
 }
 
 #[test]
 fn test_erfc_approx() {
-    compare_exact(fast::erfc, c::fasterfc, POS_FLOATS);
-    compare_exact(faster::erfc, c::fastererfc, POS_FLOATS);
+    compare_near(fast::erfc, c::fasterfc, POS_FLOATS);
+    compare_near(faster::erfc, c::fastererfc, POS_FLOATS);
 }
 
 #[test]
 fn test_erfc_exact() {
-    compare_near(fast::erfc, |x| special::Error::compl_error(x as f64) as f32, POS_FLOATS);
-    compare_far(faster::erfc, |x| special::Error::compl_error(x as f64) as f32, POS_FLOATS);
+    compare_near(
+        fast::erfc,
+        |x| special::Error::compl_error(x as f64) as f32,
+        POS_FLOATS,
+    );
+    compare_far(
+        faster::erfc,
+        |x| special::Error::compl_error(x as f64) as f32,
+        POS_FLOATS,
+    );
 }
 
 #[test]
 fn test_inverse_erf_approx() {
-    compare_exact(fast::erf_inv, c::fastinverseerf, BETWEEN_ONES);
-    compare_exact(faster::erf_inv, c::fasterinverseerf, BETWEEN_ONES);
+    compare_near(fast::erf_inv, c::fastinverseerf, BETWEEN_ONES);
+    compare_near(faster::erf_inv, c::fasterinverseerf, BETWEEN_ONES);
 }
 
 #[test]
 fn test_inverse_erf_exact() {
-    compare_near(fast::erf_inv, |x| erf::erf_inv(x as f64) as f32, BETWEEN_ONES);
-    compare_far(faster::erf_inv, |x| erf::erf_inv(x as f64) as f32, BETWEEN_ONES);
+    compare_near(
+        fast::erf_inv,
+        |x| erf::erf_inv(x as f64) as f32,
+        BETWEEN_ONES,
+    );
+    compare_far(
+        faster::erf_inv,
+        |x| erf::erf_inv(x as f64) as f32,
+        BETWEEN_ONES,
+    );
 }
 
 #[test]
 fn test_sinh_approx() {
-    compare_exact(fast::sinh, c::fastsinh, BETWEEN_PIS);
-    compare_exact(faster::sinh, c::fastersinh, BETWEEN_PIS);
+    compare_near(fast::sinh, c::fastsinh, BETWEEN_PIS);
+    compare_near(faster::sinh, c::fastersinh, BETWEEN_PIS);
 }
 
 #[test]
@@ -193,8 +245,8 @@ fn test_sinh_exact() {
 
 #[test]
 fn test_cosh_approx() {
-    compare_exact(fast::cosh, c::fastcosh, BETWEEN_PIS);
-    compare_exact(faster::cosh, c::fastercosh, BETWEEN_PIS);
+    compare_near(fast::cosh, c::fastcosh, BETWEEN_PIS);
+    compare_near(faster::cosh, c::fastercosh, BETWEEN_PIS);
 }
 
 #[test]
@@ -205,8 +257,8 @@ fn test_cosh_exact() {
 
 #[test]
 fn test_tanh_approx() {
-    compare_exact(fast::tanh, c::fasttanh, FLOATS);
-    compare_exact(faster::tanh, c::fastertanh, FLOATS);
+    compare_near(fast::tanh, c::fasttanh, FLOATS);
+    compare_near(faster::tanh, c::fastertanh, FLOATS);
 }
 
 #[test]
@@ -217,20 +269,20 @@ fn test_tanh_exact() {
 
 #[test]
 fn test_lambertw_approx() {
-    compare_exact(fast::lambertw, c::fastlambertw, FLOATS);
-    compare_exact(faster::lambertw, c::fasterlambertw, FLOATS);
+    compare_near(fast::lambertw, c::fastlambertw, FLOATS);
+    compare_near(faster::lambertw, c::fasterlambertw, FLOATS);
 }
 
 #[test]
 fn test_lambertwexpx_approx() {
-    compare_exact(fast::lambertwexpx, c::fastlambertwexpx, FLOATS);
-    compare_exact(faster::lambertwexpx, c::fasterlambertwexpx, FLOATS);
+    compare_near(fast::lambertwexpx, c::fastlambertwexpx, FLOATS);
+    compare_near(faster::lambertwexpx, c::fasterlambertwexpx, FLOATS);
 }
 
 #[test]
 fn test_sin_approx() {
-    compare_exact(fast::sin, c::fastsin, BETWEEN_PIS);
-    compare_exact(faster::sin, c::fastersin, BETWEEN_PIS);
+    compare_near(fast::sin, c::fastsin, BETWEEN_PIS);
+    compare_near(faster::sin, c::fastersin, BETWEEN_PIS);
 }
 
 #[test]
@@ -241,8 +293,8 @@ fn test_sin_exact() {
 
 #[test]
 fn test_sinfull_approx() {
-    compare_exact(fast::sinfull, c::fastsinfull, FLOATS);
-    compare_exact(faster::sinfull, c::fastersinfull, FLOATS);
+    compare_near(fast::sinfull, c::fastsinfull, FLOATS);
+    compare_near(faster::sinfull, c::fastersinfull, FLOATS);
 }
 
 #[test]
@@ -253,8 +305,8 @@ fn test_sinfull_exact() {
 
 #[test]
 fn test_cos_approx() {
-    compare_exact(fast::cos, c::fastcos, BETWEEN_PIS);
-    compare_exact(faster::cos, c::fastercos, BETWEEN_PIS);
+    compare_near(fast::cos, c::fastcos, BETWEEN_PIS);
+    compare_near(faster::cos, c::fastercos, BETWEEN_PIS);
 }
 
 #[test]
@@ -265,8 +317,8 @@ fn test_cos_exact() {
 
 #[test]
 fn test_cosfull_approx() {
-    compare_exact(fast::cosfull, c::fastcosfull, FLOATS);
-    compare_exact(faster::cosfull, c::fastercosfull, FLOATS);
+    compare_near(fast::cosfull, c::fastcosfull, FLOATS);
+    compare_near(faster::cosfull, c::fastercosfull, FLOATS);
 }
 
 #[test]
@@ -277,8 +329,8 @@ fn test_cosfull_exact() {
 
 #[test]
 fn test_tan_approx() {
-    compare_exact(fast::tan, c::fasttan, BETWEEN_HALFPIS);
-    compare_exact(faster::tan, c::fastertan, BETWEEN_HALFPIS);
+    compare_near(fast::tan, c::fasttan, BETWEEN_HALFPIS);
+    compare_near(faster::tan, c::fastertan, BETWEEN_HALFPIS);
 }
 
 #[test]
@@ -289,8 +341,8 @@ fn test_tan_exact() {
 
 #[test]
 fn test_tanfull_approx() {
-    compare_exact(fast::tanfull, c::fasttanfull, FLOATS);
-    compare_exact(faster::tanfull, c::fastertanfull, FLOATS);
+    compare_near(fast::tanfull, c::fasttanfull, FLOATS);
+    compare_near(faster::tanfull, c::fastertanfull, FLOATS);
 }
 
 #[test]


### PR DESCRIPTION
The Rust compiler does not yet optimize FMA instructions in a majority of cases. Therefore, it is recommended to use the `f32::mul_add` method to allow FMA instructions to be used. In some cases this can provide a significant speedup on machines with FMA available, and the fused mul-add instruction is reported to be more accurate than a manual floating point mul and add instruction.

Notable improvements include:
15% speedup on cos_fast
13% speedup on cos_faster
22% speedup on cosfull_fast
12% speedup on cosfull_faster
14% speedup on digamma_fast
62% speedup on erf_fast
12% speedup on erf_inv_fast
64% speedup on erfc_fast
20% speedup on exp_faster
10% speedup on lambertwexpx_fast and _faster
31% speedup on ln_gamma_fast
15% speedup on ln_gamma_faster
15% speedup on sin_fast
10% speedup on sin_faster
23% speedup on sinfull_fast
14% speedup on sinfull_faster
16% speedup on tan_fast
18% speedup on tan_faster
16% speedup on tanfull_fast
24% speedup on tanfull_faster

There is one notable regression which is pow_fast. Not really sure what's going on with that one...

Benchmarks before:

```
test cos_fast            ... bench:       2,079 ns/iter (+/- 13)
test cos_faster          ... bench:       1,036 ns/iter (+/- 7)
test cosfull_fast        ... bench:       4,918 ns/iter (+/- 18)
test cosfull_faster      ... bench:       3,433 ns/iter (+/- 10)
test cosh_fast           ... bench:       8,592 ns/iter (+/- 23)
test cosh_faster         ... bench:       2,715 ns/iter (+/- 13)
test digamma_fast        ... bench:       3,101 ns/iter (+/- 6)
test digamma_faster      ... bench:       1,830 ns/iter (+/- 2)
test digamma_special     ... bench:      12,366 ns/iter (+/- 162)
test digamma_statrs      ... bench:      13,919 ns/iter (+/- 65)
test erf_fast            ... bench:      16,029 ns/iter (+/- 50)
test erf_faster          ... bench:       1,723 ns/iter (+/- 7)
test erf_inv_fast        ... bench:       3,383 ns/iter (+/- 20)
test erf_inv_faster      ... bench:       1,552 ns/iter (+/- 5)
test erf_inv_statrs      ... bench:         690 ns/iter (+/- 5)
test erf_special         ... bench:       2,687 ns/iter (+/- 12)
test erf_statrs          ... bench:       5,183 ns/iter (+/- 35)
test erfc_fast           ... bench:      16,266 ns/iter (+/- 37)
test erfc_faster         ... bench:       1,575 ns/iter (+/- 8)
test erfc_special        ... bench:       5,200 ns/iter (+/- 19)
test exp_fast            ... bench:       4,034 ns/iter (+/- 16)
test exp_faster          ... bench:       1,333 ns/iter (+/- 13)
test lambertw_fast       ... bench:      31,768 ns/iter (+/- 42)
test lambertw_faster     ... bench:      17,991 ns/iter (+/- 42)
test lambertwexpx_fast   ... bench:      10,370 ns/iter (+/- 15)
test lambertwexpx_faster ... bench:       4,436 ns/iter (+/- 22)
test ln_fast             ... bench:       1,727 ns/iter (+/- 5)
test ln_faster           ... bench:         774 ns/iter (+/- 2)
test ln_gamma_fast       ... bench:       6,012 ns/iter (+/- 11)
test ln_gamma_faster     ... bench:       1,967 ns/iter (+/- 5)
test ln_gamma_special    ... bench:      10,542 ns/iter (+/- 124)
test ln_gamma_statrs     ... bench:      19,344 ns/iter (+/- 42)
test log2_fast           ... bench:       1,638 ns/iter (+/- 5)
test log2_faster         ... bench:         775 ns/iter (+/- 4)
test pow2_fast           ... bench:       3,760 ns/iter (+/- 6)
test pow2_faster         ... bench:         976 ns/iter (+/- 10)
test pow_fast            ... bench:       8,651 ns/iter (+/- 40)
test pow_faster          ... bench:       2,662 ns/iter (+/- 9)
test sigmoid_fast        ... bench:       4,824 ns/iter (+/- 7)
test sigmoid_faster      ... bench:       1,857 ns/iter (+/- 5)
test sin_fast            ... bench:       1,825 ns/iter (+/- 17)
test sin_faster          ... bench:       1,011 ns/iter (+/- 3)
test sinfull_fast        ... bench:       4,494 ns/iter (+/- 14)
test sinfull_faster      ... bench:       3,130 ns/iter (+/- 9)
test sinh_fast           ... bench:       8,270 ns/iter (+/- 421)
test sinh_faster         ... bench:       2,707 ns/iter (+/- 9)
test tan_fast            ... bench:       3,157 ns/iter (+/- 9)
test tan_faster          ... bench:       1,983 ns/iter (+/- 5)
test tanfull_fast        ... bench:       6,775 ns/iter (+/- 16)
test tanfull_faster      ... bench:       4,956 ns/iter (+/- 21)
test tanh_fast           ... bench:       5,683 ns/iter (+/- 34)
test tanh_faster         ... bench:       2,281 ns/iter (+/- 6)
```

After:
```
test cos_fast            ... bench:       1,768 ns/iter (+/- 22)
test cos_faster          ... bench:         902 ns/iter (+/- 4)
test cosfull_fast        ... bench:       3,818 ns/iter (+/- 9)
test cosfull_faster      ... bench:       3,006 ns/iter (+/- 12)
test cosh_fast           ... bench:       8,778 ns/iter (+/- 35)
test cosh_faster         ... bench:       2,714 ns/iter (+/- 15)
test digamma_fast        ... bench:       2,659 ns/iter (+/- 11)
test digamma_faster      ... bench:       1,775 ns/iter (+/- 7)
test digamma_special     ... bench:      12,466 ns/iter (+/- 73)
test digamma_statrs      ... bench:      13,886 ns/iter (+/- 97)
test erf_fast            ... bench:       6,062 ns/iter (+/- 58)
test erf_faster          ... bench:       1,729 ns/iter (+/- 17)
test erf_inv_fast        ... bench:       2,967 ns/iter (+/- 15)
test erf_inv_faster      ... bench:       1,420 ns/iter (+/- 6)
test erf_inv_statrs      ... bench:         689 ns/iter (+/- 3)
test erf_special         ... bench:       2,682 ns/iter (+/- 14)
test erf_statrs          ... bench:       5,311 ns/iter (+/- 182)
test erfc_fast           ... bench:       5,834 ns/iter (+/- 24)
test erfc_faster         ... bench:       1,572 ns/iter (+/- 17)
test erfc_special        ... bench:       5,206 ns/iter (+/- 35)
test exp_fast            ... bench:       3,921 ns/iter (+/- 12)
test exp_faster          ... bench:       1,060 ns/iter (+/- 11)
test lambertw_fast       ... bench:      34,830 ns/iter (+/- 59)
test lambertw_faster     ... bench:      17,537 ns/iter (+/- 33)
test lambertwexpx_fast   ... bench:       9,299 ns/iter (+/- 29)
test lambertwexpx_faster ... bench:       3,994 ns/iter (+/- 11)
test ln_fast             ... bench:       1,584 ns/iter (+/- 6)
test ln_faster           ... bench:         820 ns/iter (+/- 5)
test ln_gamma_fast       ... bench:       4,125 ns/iter (+/- 19)
test ln_gamma_faster     ... bench:       1,686 ns/iter (+/- 6)
test ln_gamma_special    ... bench:      10,540 ns/iter (+/- 76)
test ln_gamma_statrs     ... bench:      19,331 ns/iter (+/- 55)
test log2_fast           ... bench:       1,482 ns/iter (+/- 6)
test log2_faster         ... bench:         819 ns/iter (+/- 5)
test pow2_fast           ... bench:       3,642 ns/iter (+/- 15)
test pow2_faster         ... bench:         972 ns/iter (+/- 9)
test pow_fast            ... bench:       9,579 ns/iter (+/- 29)
test pow_faster          ... bench:       2,518 ns/iter (+/- 8)
test sigmoid_fast        ... bench:       4,840 ns/iter (+/- 24)
test sigmoid_faster      ... bench:       1,854 ns/iter (+/- 5)
test sin_fast            ... bench:       1,557 ns/iter (+/- 6)
test sin_faster          ... bench:         906 ns/iter (+/- 7)
test sinfull_fast        ... bench:       3,461 ns/iter (+/- 19)
test sinfull_faster      ... bench:       2,682 ns/iter (+/- 11)
test sinh_fast           ... bench:       8,587 ns/iter (+/- 37)
test sinh_faster         ... bench:       2,712 ns/iter (+/- 14)
test tan_fast            ... bench:       2,644 ns/iter (+/- 7)
test tan_faster          ... bench:       1,618 ns/iter (+/- 5)
test tanfull_fast        ... bench:       5,671 ns/iter (+/- 13)
test tanfull_faster      ... bench:       3,747 ns/iter (+/- 13)
test tanh_fast           ... bench:       5,352 ns/iter (+/- 18)
test tanh_faster         ... bench:       2,280 ns/iter (+/- 7)
```