### PR TITLE
Add std feature

### DIFF
--- a/fastapprox/Cargo.toml
+++ b/fastapprox/Cargo.toml
@@ -7,3 +7,7 @@ license = "MIT"
 repository = "https://github.com/loony-bean/fastapprox-rs"
 keywords = ["math", "machine-learning", "approximation"]
 edition = "2021"
+
+[features]
+default = ["std"]
+std = []

--- a/fastapprox/src/bits.rs
+++ b/fastapprox/src/bits.rs
@@ -4,7 +4,7 @@
 /// Similar to `f32::to_bits` but even more raw.
 #[inline]
 pub fn to_bits(x: f32) -> u32 {
-    unsafe { ::std::mem::transmute::<f32, u32>(x) }
+    unsafe { ::core::mem::transmute::<f32, u32>(x) }
 }
 
 /// Raw transmutation from `u32`.
@@ -13,5 +13,5 @@ pub fn to_bits(x: f32) -> u32 {
 /// Similar to `f32::from_bits` but even more raw.
 #[inline]
 pub fn from_bits(x: u32) -> f32 {
-    unsafe { ::std::mem::transmute::<u32, f32>(x) }
+    unsafe { ::core::mem::transmute::<u32, f32>(x) }
 }

--- a/fastapprox/src/lib.rs
+++ b/fastapprox/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 
 //! # fastapprox


### PR DESCRIPTION
These functions are useful in embedded systems as well. These typically don't have std support.

This PR adds a feature flag for enabling std support. It is enabled by default and can be disabled when needed.